### PR TITLE
Fix CI build for missing extension descriptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot --allow-dupe chapters/*.md chapters/extensions/*.md --white-list https://www.youtube.com/
+  - awesome_bot --allow-dupe chapters/*.md --white-list https://www.youtube.com/
 notifications:
   email: false


### PR DESCRIPTION
There are no pages describing extensions yet, so can't check them.  This change
can be reverted when extension descriptions are added.