### PR TITLE
Partially update links to mostly fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.2
+  - 2.4
 before_script:
   - gem install awesome_bot
 script:

--- a/chapters/opencl_3.md
+++ b/chapters/opencl_3.md
@@ -2,7 +2,7 @@
 
 OpenCL 3.0 makes the OpenCL ecosystem much more flexible by enabling vendors to focus their resources on functionality that their customers need. This is achieved by slicing all functionality beyond OpenCL 1.2 into optional features that can be queried in the API, with macros to indicate whether optional OpenCL C language features are present. This flexibility sets the stage for new extensions that becomes widely useful to be incrementally integrated into new OpenCL core specifications.
 
-OpenCL 3.0 officially removed the OpenCL C++  language from the specification, and recommends the [C++ for OpenCL](https://github.com/KhronosGroup/Khronosdotorg/blob/master/api/opencl/assets/CXX_for_OpenCL.pdf) front end compiler for those developers that wish to use C++17 for writing kernel programs.
+OpenCL 3.0 officially removed the OpenCL C++  language from the specification, and recommends the [C++ for OpenCL](https://github.com/KhronosGroup/Khronosdotorg/blob/main/api/opencl/assets/CXX_for_OpenCL.pdf) front end compiler for those developers that wish to use C++17 for writing kernel programs.
 
 Developers will find OpenCL 3.0 much easier to use as it uses a unified specification that describes all versions of OpenCL in one place rather than having a separate specification per version, making it much easier for  developers to navigate as well as making it much easier to consistently apply specification fixes and clarifications. The unified OpenCL 3.0 specification also describes the rationale behind the specification's evolution.
 

--- a/chapters/programming_opencl_kernels.md
+++ b/chapters/programming_opencl_kernels.md
@@ -24,7 +24,7 @@ To offset this portability problem, and to enable a richer language and compiler
 <br> <br>
 </p>
 
-SPIR-V enables independent innovation by the compiler and silicon communities. Compiler front ends that generate SPIR-V kernels that can be ingested and executed by any OpenCL driver that understands the SPIR-V format. For example the  [C++ for OpenCL](https://github.com/KhronosGroup/Khronosdotorg/blob/master/api/opencl/assets/CXX_for_OpenCL.pdf) open source front-end and compilers for SYCL can generate SPIR-V code.
+SPIR-V enables independent innovation by the compiler and silicon communities. Compiler front ends that generate SPIR-V kernels that can be ingested and executed by any OpenCL driver that understands the SPIR-V format. For example the  [C++ for OpenCL](https://github.com/KhronosGroup/Khronosdotorg/blob/main/api/opencl/assets/CXX_for_OpenCL.pdf) open source front-end and compilers for SYCL can generate SPIR-V code.
 
 SPIR-V also enables OpenCL kernels written in OpenCL C and C++ for OpenCL to be executed by runtimes other than OpenCL, providing more deployment flexibility for developers that have invested in OpenCL kernel programming. For example, the Google [clspv](https://github.com/google/clspv) open source compiler can generate Vulkan SPIR-V shaders from OpenCL C kernel source code, Microsoft is working on a compiler chain that can ingest [OpenCL SPIR_V kernels into DX12](https://github.com/microsoft/OpenCLOn12), and there is early work on using SPIR-V tools such as SPIRV-Cross to bring OpenCL SPIR-V kernels into Metal for execution on Apple platforms.
 


### PR DESCRIPTION
The link checker is tripping on a branch rename.

Note that one link was left unfixed to avoid a conflict due to the URL changing
completely in this PR: https://github.com/KhronosGroup/OpenCL-Guide/pull/10

Fixes #11