### PR TITLE
Update getting_started_windows.md - missing recursive flag

### DIFF
--- a/chapters/getting_started_windows.md
+++ b/chapters/getting_started_windows.md
@@ -88,7 +88,7 @@ The SDK can be installed from a package manager like Vcpkg or can be built on-de
 If you want to build an SDK from source, the recommended way is cloning the OpenCL-SDK repo.
 
 ```
-git clone https://github.com/KhronosGroup/OpenCL-SDK.git
+git clone --recursive https://github.com/KhronosGroup/OpenCL-SDK.git
 cmake -G "Visual Studio 17 2022" -A x64 -T v143 -D CMAKE_INSTALL_PREFIX=./OpenCL-SDK/install -B ./OpenCL-SDK/build -S ./OpenCL-SDK
 cmake --build OpenCL-SDK/build --config Release --target install -- /m /v:minimal
 ```


### PR DESCRIPTION
Added missing --recursive flag to 'git clone' to also clone items under 'external'